### PR TITLE
add ipaddress sync

### DIFF
--- a/resources/providers/config.rb
+++ b/resources/providers/config.rb
@@ -52,13 +52,15 @@ action :remove do
   end
 end
 action :register do
+  ipaddress = new_resource.ipaddress
+
   begin
     consul_servers = system('serf members -tag consul=ready | grep consul=ready &> /dev/null')
     if consul_servers and !node["minio"]["registered"]
       query = {}
       query["ID"] = "s3-#{node["hostname"]}"
       query["Name"] = "s3"
-      query["Address"] = "#{node["ipaddress"]}"
+      query["Address"] = ipaddress
       query["Port"] = node["minio"]["port"]
       json_query = Chef::JSONCompat.to_json(query)
 

--- a/resources/resources/config.rb
+++ b/resources/resources/config.rb
@@ -4,3 +4,5 @@ default_action :add
 attribute :user, :kind_of => String, :default => "minio"
 attribute :group, :kind_of => String, :default => "minio"
 attribute :port, :kind_of => Fixnum, :default => 9000
+
+attribute :ipaddress, :kind_of => String, :default => "127.0.0.1"


### PR DESCRIPTION
register the minio service with the sync ip address. This is needed since only the port 9000 is open in the sync network. The minio need to be access from outside through nginx service on port 443