### PR TITLE
Improvement/fix cookbook lint

### DIFF
--- a/resources/attributes/default.rb
+++ b/resources/attributes/default.rb
@@ -1,6 +1,6 @@
-default["minio"]["user"] = "minio"
-default["minio"]["group"] = "minio"
-default["minio"]["port"] = 9000
+default['minio']['user'] = 'minio'
+default['minio']['group'] = 'minio'
+default['minio']['port'] = 9000
 
-#Flags
-default["minio"]["registered"] = false
+# Flags
+default['minio']['registered'] = false

--- a/resources/metadata.rb
+++ b/resources/metadata.rb
@@ -1,6 +1,6 @@
 name             'minio'
-maintainer       'Miguel Negrón'
-maintainer_email 'manegron@redborder.com'
+maintainer       'Eneo Tecnología S.L.'
+maintainer_email 'git@redborder.com'
 license          'AGPL-3.0'
 description      'Installs/Configures Minio'
 version          '0.0.4'

--- a/resources/metadata.rb
+++ b/resources/metadata.rb
@@ -1,7 +1,6 @@
 name             'minio'
-maintainer       'Alberto Rodríguez'
-maintainer_email 'arodriguez@redborder'
-license          'AGPLv3'
+maintainer       'Miguel Negrón'
+maintainer_email 'manegron@redborder.com'
+license          'AGPL-3.0'
 description      'Installs/Configures Minio'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.0.4'

--- a/resources/providers/config.rb
+++ b/resources/providers/config.rb
@@ -1,36 +1,36 @@
-action :add do #Usually used to install and configure something
+action :add do
   begin
 
     user = new_resource.user
 
-    dnf_package "minio" do
+    dnf_package 'minio' do
       action :upgrade
       flush_cache [:before]
     end
-   
-    execute "create_user" do
-      command "/usr/sbin/useradd -r minio"
+
+    execute 'create_user' do
+      command '/usr/sbin/useradd -r minio'
       ignore_failure true
-      not_if "getent passwd minio"
+      not_if 'getent passwd minio'
     end
 
-    %w[ /var/minio /var/minio/data /etc/minio ].each do |path|
+    %w(/var/minio /var/minio/data /etc/minio).each do |path|
       directory path do
         owner user
         group user
-        mode 0755
+        mode '0755'
         action :create
       end
     end
 
-    service "minio" do
-      service_name "minio"
+    service 'minio' do
+      service_name 'minio'
       ignore_failure true
-      supports :status => true, :reload => true, :restart => true, :enable => true
+      supports status: true, reload: true, restart: true, enable: true
       action [:start, :enable]
     end
 
-     Chef::Log.info("Minio cookbook has been processed")
+    Chef::Log.info('Minio cookbook has been processed')
   rescue => e
     Chef::Log.error(e.message)
   end
@@ -39,14 +39,14 @@ end
 action :remove do
   begin
 
-    service "minio" do
-      service_name "minio"
+    service 'minio' do
+      service_name 'minio'
       ignore_failure true
-      supports :status => true, :enable => true
+      supports status: true, enable: true
       action [:stop, :disable]
     end
 
-    Chef::Log.info("Minio cookbook has been processed")
+    Chef::Log.info('Minio cookbook has been processed')
   rescue => e
     Chef::Log.error(e.message)
   end
@@ -56,24 +56,24 @@ action :register do
 
   begin
     consul_servers = system('serf members -tag consul=ready | grep consul=ready &> /dev/null')
-    if consul_servers and !node["minio"]["registered"]
+    if consul_servers && !node['minio']['registered']
       query = {}
-      query["ID"] = "s3-#{node["hostname"]}"
-      query["Name"] = "s3"
-      query["Address"] = ipaddress
-      query["Port"] = node["minio"]["port"]
+      query['ID'] = "s3-#{node['hostname']}"
+      query['Name'] = 's3'
+      query['Address'] = ipaddress
+      query['Port'] = node['minio']['port']
       json_query = Chef::JSONCompat.to_json(query)
 
       execute 'Register service in consul' do
-         command "curl -X PUT http://localhost:8500/v1/agent/service/register -d '#{json_query}' &>/dev/null"
-         retries 3
-         retry_delay 2
-         action :nothing
+        command "curl -X PUT http://localhost:8500/v1/agent/service/register -d '#{json_query}' &>/dev/null"
+        retries 3
+        retry_delay 2
+        action :nothing
       end.run_action(:run)
 
-      node.normal["minio"]["registered"] = true
+      node.normal['minio']['registered'] = true
 
-      Chef::Log.info("Minio service has been registered on consul")
+      Chef::Log.info('Minio service has been registered on consul')
     end
   rescue => e
     Chef::Log.error(e.message)
@@ -83,15 +83,15 @@ end
 action :deregister do
   begin
     consul_servers = system('serf members -tag consul=ready | grep consul=ready &> /dev/null')
-    if consul_servers and node["minio"]["registered"]
+    if consul_servers && node['minio']['registered']
       execute 'Deregister service in consul' do
-        command "curl -X PUT http://localhost:8500/v1/agent/service/deregister/s3-#{node["hostname"]} &>/dev/null"
+        command "curl -X PUT http://localhost:8500/v1/agent/service/deregister/s3-#{node['hostname']} &>/dev/null"
         action :nothing
       end.run_action(:run)
 
-      node.normal["minio"]["registered"] = false
+      node.normal['minio']['registered'] = false
 
-      Chef::Log.info("Minio service has been deregistered from consul")
+      Chef::Log.info('Minio service has been deregistered from consul')
     end
   rescue => e
     Chef::Log.error(e.message)

--- a/resources/recipes/configure_solo.rb
+++ b/resources/recipes/configure_solo.rb
@@ -1,3 +1,3 @@
-minio_config "config" do
+minio_config 'config' do
   action [:add]
 end

--- a/resources/recipes/default.rb
+++ b/resources/recipes/default.rb
@@ -1,4 +1,4 @@
-minio_config "config" do
-  mystring "test"
+minio_config 'config' do
+  mystring 'test'
   action :add
 end

--- a/resources/resources/config.rb
+++ b/resources/resources/config.rb
@@ -1,8 +1,8 @@
 actions :add, :remove, :register, :deregister
 default_action :add
 
-attribute :user, :kind_of => String, :default => "minio"
-attribute :group, :kind_of => String, :default => "minio"
-attribute :port, :kind_of => Fixnum, :default => 9000
+attribute :user, kind_of: String, default: 'minio'
+attribute :group, kind_of: String, default: 'minio'
+attribute :port, kind_of: Integer, default: 9000
 
-attribute :ipaddress, :kind_of => String, :default => "127.0.0.1"
+attribute :ipaddress, kind_of: String, default: '127.0.0.1'


### PR DESCRIPTION
- This PR addresses and fixes all important lint issues reported by cookstyle

Main Changes:
- Use of %w for word arrays
- Replace " with ' when there is not interpolation

I tested the update in a manager and seems to works, but we still need to test this with a clean installation in manager